### PR TITLE
Some fixes for MacJournal 7 and possibly a bug that specified the wro…

### DIFF
--- a/MacJournalToDayOne.py
+++ b/MacJournalToDayOne.py
@@ -88,18 +88,19 @@ def main(argv=None):
 
 			main_logger.debug("Reached EOF")
 	
-		if entryLine.startswith("\tDate:\t"): # An entry is finished
+		if entryLine.startswith("Date: "): # An entry is finished
 			prevEntryDate = curEntryDate
 			prevEntry = curEntry
 			prevEntryLines = curEntryLines
 			curEntry = ''
 			curEntryLines = 0
-			curEntryDate = entryLine.replace("\tDate:\t",'').rstrip()
+			curEntryDate = entryLine.replace("Date: ",'').rstrip()
 			entryDone = True
 			main_logger.debug("Found entry: {0}".format(curEntryDate))
-		elif entryLine.startswith('\tTopic:\t'): # The current entry topic
 			prevEntryTopic = curEntryTopic
-			curEntryTopic = entryLine.replace('\tTopic:\t','').rstrip()
+			curEntryTopic = ''
+		elif entryLine.startswith('Topic: '): # The current entry topic
+			curEntryTopic = entryLine.replace('Topic: ','').rstrip()
 		elif entryLine is not "":
 			curEntry += entryLine
 			curEntryLines += 1


### PR DESCRIPTION
This fixes two problems:
1. When trying this today I noticed the MacJournal 7 text export format didn't use tabs to delimit the Date and Topic lines.
2. Topics were off by one entry, and if an entry didn't have a topic, it used the previous topic. Now it clears the topic for each entry, so if it doesn't have a topic, none will be set.